### PR TITLE
Rename project from shift-agent to shiftagent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Thank you for your interest in contributing to the Shift Agent project! This gui
 
 1. **Fork and clone the repository**
    ```bash
-   git clone https://github.com/your-username/shift-agent.git
-   cd shift-agent
+   git clone https://github.com/your-username/shiftagent.git
+   cd shiftagent
    ```
 
 2. **Set up development environment**

--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -32,9 +32,9 @@ Add this configuration to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "shift-agent": {
+    "shiftagent": {
       "command": "uv",
-      "args": ["run", "--project", "/path/to/shift-agent", "python", "/path/to/shift-agent/mcp_server.py"],
+      "args": ["run", "--project", "/path/to/shiftagent", "python", "/path/to/shiftagent/mcp_server.py"],
       "env": {
         "SHIFT_AGENT_API_URL": "http://localhost:8081"
       }
@@ -43,7 +43,7 @@ Add this configuration to your Claude Desktop config file:
 }
 ```
 
-**Important**: Replace `/path/to/shift-agent` with the actual absolute path to your project directory.
+**Important**: Replace `/path/to/shiftagent` with the actual absolute path to your project directory.
 
 ### 3. Restart Claude Desktop
 

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ docker-build:
 
 docker-build-mcp:
 	@echo "🤖 Building MCP server Docker image..."
-	docker build -f docker/dockerfiles/Dockerfile.mcp -t shift-agent-mcp-server .
+	docker build -f docker/dockerfiles/Dockerfile.mcp -t shiftagent-mcp-server .
 
 docker-run:
 	@echo "🚀 Starting services with Docker Compose..."
@@ -262,7 +262,7 @@ docker-logs-mcp:
 # Test Docker MCP server
 test-docker-mcp:
 	@echo "🧪 Testing Docker MCP server..."
-	@echo '{"jsonrpc":"2.0","method":"list_tools","id":1}' | docker run -i --rm --network shift-agent-network shift-agent-mcp-server:latest
+	@echo '{"jsonrpc":"2.0","method":"list_tools","id":1}' | docker run -i --rm --network shiftagent-network shiftagent-mcp-server:latest
 
 # n8n integration commands
 docker-n8n-build:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![MCP Protocol](https://img.shields.io/badge/MCP-protocol-8b5cf6.svg)](https://modelcontextprotocol.io)
 
 <!-- Future CI/CD badges when GitHub Actions are set up:
-[![CI](https://github.com/vtakaj/shift-scheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/vtakaj/shift-scheduler/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/vtakaj/shift-scheduler/branch/main/graph/badge.svg)](https://codecov.io/gh/vtakaj/shift-scheduler)
-[![Security](https://github.com/vtakaj/shift-scheduler/actions/workflows/security.yml/badge.svg)](https://github.com/vtakaj/shift-scheduler/actions/workflows/security.yml)
+[![CI](https://github.com/vtakaj/shift-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/vtakaj/shift-agent/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/vtakaj/shift-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/vtakaj/shift-agent)
+[![Security](https://github.com/vtakaj/shift-agent/actions/workflows/security.yml/badge.svg)](https://github.com/vtakaj/shift-agent/actions/workflows/security.yml)
 -->
 
 An AI-powered employee shift scheduling agent using Timefold Solver with FastMCP integration for AI assistant support.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![MCP Protocol](https://img.shields.io/badge/MCP-protocol-8b5cf6.svg)](https://modelcontextprotocol.io)
 
 <!-- Future CI/CD badges when GitHub Actions are set up:
-[![CI](https://github.com/vtakaj/shift-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/vtakaj/shift-agent/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/vtakaj/shift-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/vtakaj/shift-agent)
-[![Security](https://github.com/vtakaj/shift-agent/actions/workflows/security.yml/badge.svg)](https://github.com/vtakaj/shift-agent/actions/workflows/security.yml)
+[![CI](https://github.com/vtakaj/shiftagent/actions/workflows/ci.yml/badge.svg)](https://github.com/vtakaj/shiftagent/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/vtakaj/shiftagent/branch/main/graph/badge.svg)](https://codecov.io/gh/vtakaj/shiftagent)
+[![Security](https://github.com/vtakaj/shiftagent/actions/workflows/security.yml/badge.svg)](https://github.com/vtakaj/shiftagent/actions/workflows/security.yml)
 -->
 
 An AI-powered employee shift scheduling agent using Timefold Solver with FastMCP integration for AI assistant support.
@@ -38,14 +38,14 @@ code --install-extension ms-vscode-remote.remote-containers
 **Method 1: VS Code Dev Container (Recommended)**
 ```bash
 # Open project
-code /projects/shared/shift-agent
+code /projects/shared/shiftagent
 
 # Command Palette (Cmd+Shift+P) → "Dev Containers: Reopen in Container"
 ```
 
 **Method 2: Setup Script**
 ```bash
-cd /projects/shared/shift-agent
+cd /projects/shared/shiftagent
 
 # Docker environment setup
 chmod +x setup-docker.sh
@@ -184,7 +184,7 @@ Access points:
 ## 📁 Project Structure
 
 ```
-shift-agent/
+shiftagent/
 ├── .devcontainer/          # Dev Container configuration
 │   ├── devcontainer.json   # VS Code Dev Container settings
 │   ├── docker-compose.yml  # Dev Container Docker Compose
@@ -401,9 +401,9 @@ Add to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "shift-agent": {
+    "shiftagent": {
       "command": "uv",
-      "args": ["run", "--project", "/path/to/shift-agent", "python", "/path/to/shift-agent/mcp_server.py"],
+      "args": ["run", "--project", "/path/to/shift-agent", "python", "/path/to/shiftagent/mcp_server.py"],
       "env": {
         "SHIFT_AGENT_API_URL": "http://localhost:8081"
       }

--- a/docker/compose/docker-compose.mcp.yml
+++ b/docker/compose/docker-compose.mcp.yml
@@ -4,8 +4,8 @@ services:
     build:
       context: ../..
       dockerfile: docker/dockerfiles/Dockerfile.mcp
-    image: shift-agent-mcp-server:latest
-    container_name: shift-agent-mcp-stdio
+    image: shiftagent-mcp-server:latest
+    container_name: shiftagent-mcp-stdio
     environment:
       - SHIFT_AGENT_API_URL=http://host.docker.internal:8081
       - LOG_LEVEL=INFO
@@ -20,8 +20,8 @@ services:
     build:
       context: ../..
       dockerfile: docker/dockerfiles/Dockerfile.mcp.http
-    image: shift-agent-mcp-http:latest
-    container_name: shift-agent-mcp-http
+    image: shiftagent-mcp-http:latest
+    container_name: shiftagent-mcp-http
     ports:
       - "8083:8083"
     environment:
@@ -46,8 +46,8 @@ services:
     build:
       context: ../..
       dockerfile: docker/dockerfiles/Dockerfile.mcp.sse
-    image: shift-agent-mcp-sse:latest
-    container_name: shift-agent-mcp-sse
+    image: shiftagent-mcp-sse:latest
+    container_name: shiftagent-mcp-sse
     ports:
       - "8084:8084"
     environment:
@@ -68,5 +68,5 @@ services:
 
 networks:
   default:
-    name: shift-agent-mcp-network
+    name: shiftagent-mcp-network
     external: false

--- a/docker/compose/docker-compose.prod.yml
+++ b/docker/compose/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 services:
-  shift-agent:
+  shiftagent:
     build:
       context: ../..
       dockerfile: docker/dockerfiles/Dockerfile
@@ -24,7 +24,7 @@ services:
       # Production: Only job storage, no source code mounts
       - job_data:/app/job_storage
       # Optional: Bind mount for persistent storage
-      # - ${HOST_JOB_STORAGE_DIR:-/var/lib/shift-agent}:/app/job_storage
+      # - ${HOST_JOB_STORAGE_DIR:-/var/lib/shiftagent}:/app/job_storage
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
       interval: 30s
@@ -36,7 +36,7 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      - shift-network
+      - shiftnetwork
     deploy:
       resources:
         limits:
@@ -67,7 +67,7 @@ services:
       start_period: 30s
     restart: always
     networks:
-      - shift-network
+      - shiftnetwork
     deploy:
       resources:
         limits:
@@ -97,7 +97,7 @@ services:
         condition: service_healthy
     restart: always
     networks:
-      - shift-network
+      - shiftnetwork
     profiles:
       - mcp
     deploy:
@@ -125,7 +125,7 @@ services:
       - shift-agent
     restart: always
     networks:
-      - shift-network
+      - shiftnetwork
     profiles:
       - nginx
     deploy:
@@ -148,7 +148,7 @@ services:
       retries: 3
     restart: always
     networks:
-      - shift-network
+      - shiftnetwork
     profiles:
       - cache
     deploy:
@@ -168,9 +168,9 @@ volumes:
     driver: local
 
 networks:
-  shift-network:
+  shiftnetwork:
     driver: bridge
-    name: shift-agent-network-prod
+    name: shiftagent-network-prod
 
 # Production secrets (use Docker secrets in swarm mode)
 secrets:

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  shift-agent:
+  shiftagent:
     build:
       context: ../..
       dockerfile: docker/dockerfiles/Dockerfile.api
@@ -36,7 +36,7 @@ services:
     depends_on:
       - postgres
     networks:
-      - shift-network
+      - shiftnetwork
 
   # PostgreSQL database (optional for future use)
   postgres:
@@ -59,7 +59,7 @@ services:
       start_period: 30s
     restart: unless-stopped
     networks:
-      - shift-network
+      - shiftnetwork
 
   # MCP Server (for AI assistant integration)
   mcp-server:
@@ -79,7 +79,7 @@ services:
       - ../../pyproject.toml:/app/pyproject.toml:ro
     restart: unless-stopped
     networks:
-      - shift-network
+      - shiftnetwork
     profiles:
       - mcp
 
@@ -88,6 +88,6 @@ volumes:
     driver: local
 
 networks:
-  shift-network:
+  shiftnetwork:
     driver: bridge
-    name: shift-agent-network
+    name: shiftagent-network

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "shift-agent"
+name = "shiftagent"
 version = "1.0.0"
 description = "AI-powered employee shift scheduling agent using Timefold Solver"
 readme = "README.md"
@@ -39,8 +39,8 @@ dev = [
 
 # Console scripts for uvx support
 [project.scripts]
-shift-agent-api = "shift_agent.api.server:main"
-shift-agent-mcp = "shift_agent_mcp.server:main"
+shiftagent-api = "shift_agent.api.server:main"
+shiftagent-mcp = "shift_agent_mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/shift_agent/api/server.py
+++ b/src/shift_agent/api/server.py
@@ -10,7 +10,7 @@ from .routes import *  # noqa: F401, F403 - Import all routes to register them
 
 
 def main():
-    """Main entry point for the shift-agent-api console script"""
+    """Main entry point for the shiftagent-api console script"""
     uvicorn.run(app, host="0.0.0.0", port=8081, log_level="info")
 
 


### PR DESCRIPTION
## Summary
- Standardize project naming by removing hyphen from shift-agent to shiftagent
- Update package name in pyproject.toml and all references throughout codebase
- Update Docker image names, container names, and network names
- Update documentation paths and repository URLs

## Test plan
- [ ] Verify application still runs with new package name
- [ ] Test Docker builds with new image names
- [ ] Confirm MCP server still works with updated script names
- [ ] Check all documentation links and references

🤖 Generated with [Claude Code](https://claude.ai/code)